### PR TITLE
Add support for Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "^6.5.8|^7.4.5"
     },
     "require-dev": {
 


### PR DESCRIPTION
Support for Guzzle 7 which is required in Laravel 8 and up.